### PR TITLE
Remove test files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+test/
+npm-debug.log
+.travis.yml


### PR DESCRIPTION
Hello!

I've noticed your [npm package contains some test files](https://zitros.github.io/npm-explorer/?p=hmac-drbg) which are redundant. This pull request will prevent them from going to an npm registry on a next publish.

Thanks!