### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 
 language: node_js
-
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - "4"
   - "6"


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/hmac-drbg/builds/209187848
Please have a look.

Regards,
ujjwal