### PR TITLE
Make hmac-drbg tree-shakeable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+package-lock.json

--- a/lib/hmac-drbg.js
+++ b/lib/hmac-drbg.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var hash = require('hash.js');
-var utils = require('minimalistic-crypto-utils');
-var assert = require('minimalistic-assert');
+import hash from "hash.js"
+import utils from 'minimalistic-crypto-utils';
+import assert from 'minimalistic-assert';
 
 function HmacDRBG(options) {
   if (!(this instanceof HmacDRBG))
@@ -25,7 +25,7 @@ function HmacDRBG(options) {
          'Not enough entropy. Minimum is: ' + this.minEntropy + ' bits');
   this._init(entropy, nonce, pers);
 }
-module.exports = HmacDRBG;
+export default HmacDRBG;
 
 HmacDRBG.prototype._init = function init(entropy, nonce, pers) {
   var seed = entropy.concat(nonce).concat(pers);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Deterministic random bit generator (hmac)",
   "main": "lib/hmac-drbg.js",
+  "type": "module",
   "scripts": {
     "test": "mocha --reporter=spec test/*-test.js"
   },
@@ -22,7 +23,7 @@
   },
   "homepage": "https://github.com/indutny/hmac-drbg#readme",
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^9.2.1"
   },
   "dependencies": {
     "hash.js": "^1.0.3",

--- a/test/drbg-test.js
+++ b/test/drbg-test.js
@@ -1,8 +1,10 @@
 'use strict';
 
-const assert = require('assert');
-const HmacDRBG = require('../');
-const hash = require('hash.js');
+import assert from 'assert';
+import HmacDRBG from '../lib/hmac-drbg.js';
+import hash from 'hash.js';
+import fs from "fs"
+import { resolve } from "path"
 
 describe('Hmac_DRBG', () => {
   it('should support hmac-drbg-sha256', () => {
@@ -40,7 +42,7 @@ describe('Hmac_DRBG', () => {
   });
 
   describe('NIST vector', function() {
-    require('./fixtures/hmac-drbg-nist.json').forEach(function (opt) {
+    JSON.parse(fs.readFileSync(resolve('test/fixtures/hmac-drbg-nist.json'))).forEach(function (opt) {
       it('should not fail at ' + opt.name, function() {
         const drbg = HmacDRBG({
           hash: hash.sha256,


### PR DESCRIPTION
This moves to modern ES modules that make the dependencies tree-shakeable, thus reducing size.

If the author is interested, I can also port this to TypeScript and move the object to being a class instead.